### PR TITLE
Make `ReadableDoc.Progress` Properties Immutable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Install Swift
         if: ${{ matrix.platform == 'windows-latest' }}
         uses: MaxDesiatov/swift-windows-action@v1
-          with:
-            shell-action: swift -h
+        with:
+          shell-action: swift -h
       - name: Build Sources
         run: swift build
       - name: Build Tests

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -100,10 +100,10 @@ extension ReadableDoc {
     /// The context in which an error occured.
     public struct Progress {
         /// The partially parsed key-value pairs.
-        internal(set) public var parsed: ReadableDoc
+        public let parsed: ReadableDoc
 
         /// The remaining unparsed data.
-        internal(set) public var remaining: Data.SubSequence
+        public let remaining: Data.SubSequence
     }
 }
 


### PR DESCRIPTION
### Objective

This pull request makes the properties of `ReadableDoc.Progress` immutable.

### Alternatives Considered

The original properties were defined as `internal(set)` to use them as the primary storage during initialization. In practice, the initializer was never updated, and the progress value was always initialized right before throwing. There is no obvious code hygiene or performance benefit either way.
