### PR TITLE
Fix the Scheme Name in the Test Workflow File

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Test
 on:
   pull_request:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Test
 on:
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -26,6 +25,8 @@ jobs:
       - name: Install Swift
         if: ${{ matrix.platform == 'windows-latest' }}
         uses: MaxDesiatov/swift-windows-action@v1
+          with:
+            shell-action: swift -h
       - name: Build Sources
         run: swift build
       - name: Build Tests
@@ -50,7 +51,7 @@ jobs:
           destinationName: watchOS 8.3
     name: Test on ${{ matrix.destinationName }}
     env:
-      SCHEME: swift-bson-Package
+      SCHEME: swift-bison-Package
     steps:
     - uses: actions/checkout@v2
     - name: Build Sources


### PR DESCRIPTION
### Objectives

This pull request renames the $SCHEME environment variable in the `test.yml` workflow file from `swift-bson-Package` to `swift-bison-Package` following the project rebrand.

A shell action was specified to `swift-windows-action` to avoid building and testing the package twice on Windows.
