### PR TITLE
Replace the output of WritableValue types to Foundation Data

### DIFF
--- a/Sources/BisonEncode/BSONEncoder.swift
+++ b/Sources/BisonEncode/BSONEncoder.swift
@@ -34,6 +34,6 @@ public struct BSONEncoder {
     public func encode<T: Encodable>(_ value: T) throws -> Data {
         let containerProvider = BSONEncodingContainerProvider(codingPath: [])
         try value.encode(to: containerProvider)
-        return Data(containerProvider.bsonBytes)
+        return containerProvider.bsonBytes
     }
 }

--- a/Sources/BisonEncode/BSONEncodingContainerProvider.swift
+++ b/Sources/BisonEncode/BSONEncodingContainerProvider.swift
@@ -6,6 +6,7 @@
 //
 
 import BisonWrite
+import Foundation
 
 class BSONEncodingContainerProvider {
     /// The container selected by the object to encode.
@@ -21,10 +22,10 @@ class BSONEncodingContainerProvider {
     init(codingPath: [CodingKey]) {
         self.codingPath = codingPath
     }
-}
+} 
 
 extension BSONEncodingContainerProvider: WritableValue {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         container!.bsonBytes
     }
 

--- a/Sources/BisonEncode/BSONKeyedEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONKeyedEncodingContainer.swift
@@ -6,6 +6,7 @@
 //
 
 import BisonWrite
+import Foundation
 
 class BSONKeyedEncodingContainer<Key: CodingKey> {
     /// The contents of this container.
@@ -21,7 +22,7 @@ class BSONKeyedEncodingContainer<Key: CodingKey> {
 }
 
 extension BSONKeyedEncodingContainer: WritableValue {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         let contents = self.contents
         return WritableDoc {
             ForEach(contents) { key, value in 

--- a/Sources/BisonEncode/BSONSingleValueEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONSingleValueEncodingContainer.swift
@@ -6,10 +6,11 @@
 //
 
 import BisonWrite
+import Foundation
 
 class BSONSingleValueEncodingContainer {
     /// The value assigned to this container.
-    var encodedValue: [UInt8]? = nil
+    var encodedValue: Data? = nil
 
     /// The type byte declared by the value assigned to this container.
     var encodedType: UInt8? = nil
@@ -24,7 +25,7 @@ class BSONSingleValueEncodingContainer {
 }
 
 extension BSONSingleValueEncodingContainer: WritableValue {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         encodedValue!
     }
 
@@ -35,7 +36,7 @@ extension BSONSingleValueEncodingContainer: WritableValue {
 
 extension BSONSingleValueEncodingContainer: SingleValueEncodingContainer {
     func encodeNil() throws {
-        encodedValue = []
+        encodedValue = Data()
         encodedType = 10
     }
 

--- a/Sources/BisonEncode/BSONUnkeyedEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONUnkeyedEncodingContainer.swift
@@ -6,6 +6,7 @@
 //
 
 import BisonWrite
+import Foundation
 
 class BSONUnkeyedEncodingContainer {
     /// The contents of this container.
@@ -27,7 +28,7 @@ extension Array where Element == ValueBox {
 }
 
 extension BSONUnkeyedEncodingContainer: WritableValue {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         let contents = self.contents
         return WritableDoc {
             ForEach(contents.enumerated()) { index, value in 

--- a/Sources/BisonEncode/ValueBox.swift
+++ b/Sources/BisonEncode/ValueBox.swift
@@ -6,6 +6,7 @@
 //
 
 import BisonWrite
+import Foundation
 
 /// A box around a value conforming to `WritableValue`.
 struct ValueBox {
@@ -24,7 +25,7 @@ struct ValueBox {
 }
 
 extension ValueBox: WritableValue {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         value.bsonBytes
     }
 

--- a/Sources/BisonWrite/Components/DocComponent.swift
+++ b/Sources/BisonWrite/Components/DocComponent.swift
@@ -5,8 +5,10 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
+import Foundation
+
 /// A basic building block of a BSON document.
 public protocol DocComponent {
     /// This component's BSON-encoded bytes.
-    var bsonBytes: [UInt8] { get }
+    var bsonBytes: Data { get }
 }

--- a/Sources/BisonWrite/Components/ForEach.swift
+++ b/Sources/BisonWrite/Components/ForEach.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
+import Foundation
+
 /// Encodes a sequence into a document using the provided closure.
 public struct ForEach<Base: Sequence, Element: DocComponent>: DocComponent {
     /// The transformed elements of this loop.
@@ -26,7 +28,11 @@ public struct ForEach<Base: Sequence, Element: DocComponent>: DocComponent {
         self.elements = base.lazy.map(transform)
     }
     
-    public var bsonBytes: [UInt8] {
-        elements.flatMap { $0.bsonBytes }
+    public var bsonBytes: Data {
+        var encodedElements = Data()
+        for component in elements {
+            encodedElements.append(component.bsonBytes)
+        }
+        return encodedElements
     }
 }

--- a/Sources/BisonWrite/Components/Group.swift
+++ b/Sources/BisonWrite/Components/Group.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
+import Foundation
+
 /// A group of document components values.
 /// 
 /// Use a `Group` when you need to declare more than 10 components in a document.
@@ -26,7 +28,7 @@ public struct Group<Body: DocComponent>: DocComponent {
         self.body = try body()
     }
 
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         body.bsonBytes
     }
 }

--- a/Sources/BisonWrite/Components/OptionalComponent.swift
+++ b/Sources/BisonWrite/Components/OptionalComponent.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 16 2022
 //
 
+import Foundation
+
 /// A wrapper type for an optional component used exclusively by ``DocBuilder/buildOptional(_:)``.
 enum OptionalComponent<T: DocComponent>: DocComponent {
     /// A non-nil component.
@@ -23,12 +25,12 @@ enum OptionalComponent<T: DocComponent>: DocComponent {
         }
     }
 
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         switch self {
         case .some(let component):
             return component.bsonBytes
         case .none:
-            return []
+            return Data()
         }
     }
 }

--- a/Sources/BisonWrite/Components/Pair.swift
+++ b/Sources/BisonWrite/Components/Pair.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
+import Foundation
+
 /// A key-value pair used to compose a BSON document.
 /// 
 /// To create a `Pair`, use the `=>` operator on a `String` and a `WritableValue` conforming value:
@@ -17,10 +19,10 @@ public struct Pair<T: WritableValue>: DocComponent {
     let key: String
     let value: T
     
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         // Copy the key bytes
         let keyCodeUnits = key.utf8
-        var pairBytes: [UInt8] = []
+        var pairBytes = Data()
         pairBytes.reserveCapacity(key.count + 2)
         pairBytes.append(value.bsonType)
         pairBytes.append(contentsOf: keyCodeUnits)

--- a/Sources/BisonWrite/Tuples/Tuple+DocComponent.swift
+++ b/Sources/BisonWrite/Tuples/Tuple+DocComponent.swift
@@ -5,8 +5,10 @@
 //  Created by Christopher Richez on March 15 2022
 //
 
+import Foundation
+
 extension Tuple2: DocComponent where T0: DocComponent, T1: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         return concatenatedComponents
@@ -19,7 +21,7 @@ extension Tuple2: DocComponent where T0: DocComponent, T1: DocComponent {
 }
 
 extension Tuple3: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -35,7 +37,7 @@ extension Tuple3: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 
 extension Tuple4: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -53,7 +55,7 @@ extension Tuple4: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 
 extension Tuple5: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent, T4: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -73,7 +75,7 @@ extension Tuple5: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 
 extension Tuple6: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent, T4: DocComponent, T5: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -95,7 +97,7 @@ extension Tuple6: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 
 extension Tuple7: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent, T4: DocComponent, T5: DocComponent, T6: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -119,7 +121,7 @@ extension Tuple7: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 
 extension Tuple8: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent, T4: DocComponent, T5: DocComponent, T6: DocComponent, T7: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -146,7 +148,7 @@ extension Tuple8: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 extension Tuple9: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent, 
   T3: DocComponent, T4: DocComponent, T5: DocComponent, T6: DocComponent, T7: DocComponent, 
   T8: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)
@@ -175,7 +177,7 @@ extension Tuple9: DocComponent where T0: DocComponent, T1: DocComponent, T2: Doc
 extension Tuple10: DocComponent where T0: DocComponent, T1: DocComponent, T2: DocComponent,
   T3: DocComponent, T4: DocComponent, T5: DocComponent, T6: DocComponent, T7: DocComponent,
   T8: DocComponent, T9: DocComponent {
-    var bsonBytes: [UInt8] {
+    var bsonBytes: Data {
         var concatenatedComponents = t0.bsonBytes
         concatenatedComponents.append(contentsOf: t1.bsonBytes)
         concatenatedComponents.append(contentsOf: t2.bsonBytes)

--- a/Sources/BisonWrite/Values/CustomWritableValue.swift
+++ b/Sources/BisonWrite/Values/CustomWritableValue.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on April 14 2022
 //
 
+import Foundation
+
 /// A BSON value that declares the `binary` type (5).
 /// 
 /// Conform to `CustomWritableValue` instead of `WritableValue` for binary values.
@@ -15,7 +17,7 @@ public protocol CustomWritableValue: WritableValue {
     var bsonSubtype: UInt8 { get }
 
     /// The bytes of the value itself, not including its size and subtype.
-    var bsonValueBytes: [UInt8] { get }
+    var bsonValueBytes: Data { get }
 }
 
 extension CustomWritableValue {
@@ -23,7 +25,7 @@ extension CustomWritableValue {
         5
     }
 
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         let valueBytes = bsonValueBytes
         var bsonBytes = Int32(valueBytes.count).bsonBytes
         bsonBytes.append(bsonSubtype)

--- a/Sources/BisonWrite/Values/Data+CustomWritableValue.swift
+++ b/Sources/BisonWrite/Values/Data+CustomWritableValue.swift
@@ -12,7 +12,7 @@ extension Data: CustomWritableValue {
         0
     }
 
-    public var bsonValueBytes: [UInt8] {
-        Array(self)
+    public var bsonValueBytes: Data {
+        self
     }
 }

--- a/Sources/BisonWrite/Values/Date+WritableValue.swift
+++ b/Sources/BisonWrite/Values/Date+WritableValue.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension Date: WritableValue {
     public var bsonType: UInt8 { 9 }
-    public var bsonBytes: [UInt8] { 
+    public var bsonBytes: Data { 
         let seconds = timeIntervalSince1970
         let milliseconds = seconds * 1000
         return Int64(milliseconds).bsonBytes

--- a/Sources/BisonWrite/Values/ObjectID+WritableValue.swift
+++ b/Sources/BisonWrite/Values/ObjectID+WritableValue.swift
@@ -6,8 +6,9 @@
 //
 
 import ObjectID
+import Foundation
 
 extension ObjectID: WritableValue {
     public var bsonType: UInt8 { 7 }
-    public var bsonBytes: [UInt8] { withUnsafeBytes(of: self) { Array($0) } }
+    public var bsonBytes: Data { withUnsafeBytes(of: self) { Data($0) } }
 }

--- a/Sources/BisonWrite/Values/UUID+CustomWritableValue.swift
+++ b/Sources/BisonWrite/Values/UUID+CustomWritableValue.swift
@@ -12,9 +12,9 @@ extension UUID: CustomWritableValue {
         4
     }
 
-    public var bsonValueBytes: [UInt8] {
+    public var bsonValueBytes: Data {
         withUnsafeBytes(of: self) { bytes in 
-            Array(bytes)
+            Data(bytes)
         }
     }
 }

--- a/Sources/BisonWrite/Values/WritableArray.swift
+++ b/Sources/BisonWrite/Values/WritableArray.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 31 2022
 //
 
+import Foundation
+
 /// A BSON document used exclusively for encoding.
 public struct WritableArray<Body: DocComponent> {
     /// The contents of this document.
@@ -17,8 +19,9 @@ public struct WritableArray<Body: DocComponent> {
 }
 
 extension WritableArray: WritableValue {
-    public var bsonBytes: [UInt8] {
-        let encodedBody = body.bsonBytes + [0]
+    public var bsonBytes: Data {
+        var encodedBody = body.bsonBytes
+        encodedBody.append(0)
         let encodedSize = Int32(encodedBody.count + 4).bsonBytes
         return encodedSize + encodedBody
     }

--- a/Sources/BisonWrite/Values/WritableDoc.swift
+++ b/Sources/BisonWrite/Values/WritableDoc.swift
@@ -5,6 +5,8 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
+import Foundation
+
 /// A BSON document used exclusively for encoding.
 public struct WritableDoc<Body: DocComponent> {
     /// The contents of this document.
@@ -17,8 +19,9 @@ public struct WritableDoc<Body: DocComponent> {
 }
 
 extension WritableDoc: WritableValue {
-    public var bsonBytes: [UInt8] {
-        let encodedBody = body.bsonBytes + [0]
+    public var bsonBytes: Data {
+        var encodedBody = body.bsonBytes
+        encodedBody.append(0)
         let encodedSize = Int32(encodedBody.count + 4).bsonBytes
         return encodedSize + encodedBody
     }

--- a/Sources/BisonWrite/Values/WritableValue.swift
+++ b/Sources/BisonWrite/Values/WritableValue.swift
@@ -5,19 +5,21 @@
 //  Created by Christopher Richez on 2/6/22.
 //
 
+import Foundation
+
 /// A value that can be assigned to a ``Pair`` in a BSON document.
 public protocol WritableValue {
     /// The BSON type byte for this type.
     var bsonType: UInt8 { get }
     
     /// This value's BSON-encoded bytes.
-    var bsonBytes: [UInt8] { get }
+    var bsonBytes: Data { get }
 }
 
 extension Int32: WritableValue {
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         withUnsafeBytes(of: self) { bytes in
-            Array(bytes)
+            Data(bytes)
         }
     }
 
@@ -27,8 +29,8 @@ extension Int32: WritableValue {
 }
 
 extension String: WritableValue {
-    public var bsonBytes: [UInt8] {
-        let content = Array(utf8) + [0]
+    public var bsonBytes: Data {
+        let content = Data(utf8) + [0]
         guard let size = Int32(exactly: content.count)?.bsonBytes else {
             fatalError("string too long")
         }
@@ -41,8 +43,8 @@ extension String: WritableValue {
 }
 
 extension Bool: WritableValue {
-    public var bsonBytes: [UInt8] {
-        self ? [1] : [0]
+    public var bsonBytes: Data {
+        self ? Data([1]) : Data([0])
     }
     
     public var bsonType: UInt8 {
@@ -51,9 +53,9 @@ extension Bool: WritableValue {
 }
 
 extension Int64: WritableValue {
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         withUnsafeBytes(of: self) { bytes in
-            Array(bytes)
+            Data(bytes)
         }
     }
     
@@ -63,9 +65,9 @@ extension Int64: WritableValue {
 }
 
 extension UInt64: WritableValue {
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         withUnsafeBytes(of: self) { bytes in
-            Array(bytes)
+            Data(bytes)
         }
     }
     
@@ -75,9 +77,9 @@ extension UInt64: WritableValue {
 }
 
 extension Double: WritableValue {
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         withUnsafeBytes(of: bitPattern) { bytes in
-            Array(bytes)
+            Data(bytes)
         }
     }
     
@@ -87,12 +89,12 @@ extension Double: WritableValue {
 }
 
 extension Optional: WritableValue where Wrapped : WritableValue {
-    public var bsonBytes: [UInt8] {
+    public var bsonBytes: Data {
         switch self {
         case .some(let value):
             return value.bsonBytes
         case .none:
-            return []
+            return Data()
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -21,7 +21,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "hello" => "world!"
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(String.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -39,7 +39,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value 
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertTrue(try container.decodeNil(forKey: .test))
     }
 
@@ -49,7 +49,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertFalse(try container.decodeNil(forKey: .test))
     }
 
@@ -59,7 +59,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(Double.self, forKey: .test), value)
     }
 
@@ -68,7 +68,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int32(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(Double.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -87,7 +87,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => "passed?"
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(String.self, forKey: .test), "passed?")
     }
 
@@ -96,7 +96,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int32(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(String.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -113,7 +113,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int64(2)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(String.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -130,7 +130,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => false
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertFalse(try container.decode(Bool.self, forKey: .test))
     }
 
@@ -139,7 +139,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => UInt64(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(Bool.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -159,7 +159,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(Int32.self, forKey: .test), value)
     }
 
@@ -168,7 +168,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => UInt64(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(Int32.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -188,7 +188,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(Int64.self, forKey: .test), value)
     }
 
@@ -197,7 +197,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int32(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(Int64.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -217,7 +217,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(UInt64.self, forKey: .test), value)
     }
 
@@ -226,7 +226,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int32(0)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.decode(UInt64.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -246,7 +246,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(Int64?.self, forKey: .test), value)
     }
 
@@ -261,7 +261,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(Data.self, forKey: .test), value)
     }
 
@@ -273,7 +273,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             }
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         let nestedContainer = try container.nestedContainer(keyedBy: Key.self, forKey: .test)
         XCTAssertEqual(try nestedContainer.decode(String.self, forKey: .test), value)
     }
@@ -283,7 +283,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => Int32.random(in: .min ... .max)
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         do {
             let decodedValue = try container.nestedContainer(keyedBy: Key.self, forKey: .test)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
@@ -291,7 +291,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == KeyedDecodingContainer<Key>.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = context.underlyingError 
-                as? ReadableDoc<Array<UInt8>.SubSequence>.Error
+                as? ReadableDoc<Data.SubSequence>.Error
             let unwrappedError = try XCTUnwrap(underlyingError)
             XCTAssertEqual(unwrappedError, .docTooShort)
         }
@@ -305,7 +305,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             }
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         var nestedContainer = try container.nestedUnkeyedContainer(forKey: .test)
         XCTAssertEqual(try nestedContainer.decode(String.self), value)
     }
@@ -316,7 +316,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "super" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         let superDecoder = try container.superDecoder()
         XCTAssertEqual(try Bool(from: superDecoder), value)
     }
@@ -327,7 +327,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             "test" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        let container = BSONKeyedDecodingContainer<[UInt8], Key>(doc: parsedDoc)
+        let container = BSONKeyedDecodingContainer<Data, Key>(doc: parsedDoc)
         let superDecoder = try container.superDecoder(forKey: .test)
         XCTAssertEqual(try Bool(from: superDecoder), value)
     }

--- a/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
@@ -191,7 +191,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
     /// array document of `UInt64` values.
     func testDecodeBSONValue() throws {
         let value = Data([1, 2, 3, 4])
-        let container = BSONSingleValueDecodingContainer<[UInt8]>(
+        let container = BSONSingleValueDecodingContainer<Data>(
             contents: value.bsonBytes, 
             codingPath: [])
         XCTAssertEqual(try container.decode(Data.self), value)

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -229,7 +229,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             "0" => value
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)
-        var container = BSONUnkeyedDecodingContainer<[UInt8]>(doc: parsedDoc)
+        var container = BSONUnkeyedDecodingContainer<Data>(doc: parsedDoc)
         XCTAssertEqual(try container.decode(UUID.self), value)
     }
 

--- a/Tests/BisonWriteTests/CustomWritableValueTests.swift
+++ b/Tests/BisonWriteTests/CustomWritableValueTests.swift
@@ -15,12 +15,12 @@ class CustomWritableValueTests: XCTestCase {
         let doc = WritableDoc {
             "" => id
         }
-        var expectedDoc: [UInt8] = [
+        var expectedDoc = Data([
             /* size: */ 28, 0, 0, 0,
             /* key: */ 5, 0,
             /* value size: */ 16, 0, 0, 0,
             /* subtype: */ 4, 
-        ]
+        ])
         expectedDoc.append(contentsOf: withUnsafeBytes(of: id) { Array($0) })
         expectedDoc.append(0)
         XCTAssertEqual(doc.bsonBytes, expectedDoc)
@@ -31,14 +31,14 @@ class CustomWritableValueTests: XCTestCase {
         let doc = WritableDoc {
             "" => data
         }
-        let expectedDoc: [UInt8] = [
+        let expectedDoc = Data([
             /* size: */ 16, 0, 0, 0,
             /* key: */ 5, 0,
             /* value size: */ 4, 0, 0, 0,
             /* subtype: */ 0, 
             /* value data: */ 0, 1, 2, 3,
             /* doc terminator: */ 0,
-        ]
+        ])
         XCTAssertEqual(doc.bsonBytes, expectedDoc)
     }
 

--- a/Tests/BisonWriteTests/DocComponentTests.swift
+++ b/Tests/BisonWriteTests/DocComponentTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class DocComponentTests: XCTestCase {
     func testPair() {
         let pair = "\0" => true
-        let expectedPair: [UInt8] = [8, 0, 0, 1]
+        let expectedPair = Data([8, 0, 0, 1])
         XCTAssertEqual(pair.bsonBytes, expectedPair)
     }
 
@@ -73,6 +73,6 @@ class DocComponentTests: XCTestCase {
         XCTAssertEqual(some.bsonBytes, expectedSome.bsonBytes)
 
         let none = OptionalComponent<Pair<Bool>>.none
-        XCTAssertEqual(none.bsonBytes, [])
+        XCTAssertEqual(none.bsonBytes, Data())
     }
 }

--- a/Tests/BisonWriteTests/WritableValueTests.swift
+++ b/Tests/BisonWriteTests/WritableValueTests.swift
@@ -13,7 +13,7 @@ class WritableValueTests: XCTestCase {
     func testDouble() throws {
         let value = Double.random(in: .leastNonzeroMagnitude ... .greatestFiniteMagnitude)
         let expectedType: UInt8 = 1
-        let expectedBytes = withUnsafeBytes(of: value.bitPattern) { Array($0) }
+        let expectedBytes = withUnsafeBytes(of: value.bitPattern) { Data($0) }
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }
@@ -21,7 +21,7 @@ class WritableValueTests: XCTestCase {
     func testString() throws {
         let value = "this is a test! \u{10097}"
         let expectedType: UInt8 = 2
-        let expectedBytes = Int32(value.utf8.count + 1).bsonBytes + Array(value.utf8) + [0]
+        let expectedBytes = Int32(value.utf8.count + 1).bsonBytes + Data(value.utf8) + [0]
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }
@@ -29,7 +29,7 @@ class WritableValueTests: XCTestCase {
     func testBool() throws {
         let value = Bool.random()
         let expectedType: UInt8 = 8
-        let expectedBytes: [UInt8] = value ? [1] : [0]
+        let expectedBytes = value ? Data([1]) : Data([0])
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }
@@ -37,7 +37,7 @@ class WritableValueTests: XCTestCase {
     func testInt32() throws {
         let value = Int32.random(in: .min ... .max)
         let expectedType: UInt8 = 16
-        let expectedBytes = withUnsafeBytes(of: value) { Array($0) }
+        let expectedBytes = withUnsafeBytes(of: value) { Data($0) }
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }
@@ -45,7 +45,7 @@ class WritableValueTests: XCTestCase {
     func testUInt64() throws {
         let value = UInt64.random(in: .min ... .max)
         let expectedType: UInt8 = 17
-        let expectedBytes = withUnsafeBytes(of: value) { Array($0) }
+        let expectedBytes = withUnsafeBytes(of: value) { Data($0) }
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }
@@ -53,7 +53,7 @@ class WritableValueTests: XCTestCase {
     func testInt64() throws {
         let value = Int64.random(in: .min ... .max)
         let expectedType: UInt8 = 18
-        let expectedBytes = withUnsafeBytes(of: value) { Array($0) }
+        let expectedBytes = withUnsafeBytes(of: value) { Data($0) }
         XCTAssertEqual(value.bsonType, expectedType)
         XCTAssertEqual(value.bsonBytes, expectedBytes)
     }


### PR DESCRIPTION
## Objectives

This pull request changes the type of the `ValueProcol.bsonBytes` type to `Foundation.Data` and closes #39.

## Overview

See #39.
