### PR TITLE
Custom Array Document API

### DIFF
--- a/Sources/BisonWrite/ArrayDocBuilder.swift
+++ b/Sources/BisonWrite/ArrayDocBuilder.swift
@@ -1,0 +1,46 @@
+//
+//  ArrayDocBuilder.swift
+//
+//
+//  Created by Christopher Richez on July 29th 2022.
+//
+
+extension Array: DocComponent where Element == WritableValue {
+    public func append<Doc>(to document: inout Doc) 
+    where Doc : RangeReplaceableCollection, Doc.Element == UInt8 {
+        for (index, value) in self.enumerated() {
+            document.append(value.bsonType)
+            document.append(contentsOf: String(index).utf8)
+            document.append(0)
+            value.append(to: &document)
+        }
+    }
+}
+
+@resultBuilder public struct ArrayDocBuilder {
+    public static func buildExpression(_ expression: WritableValue) -> Array<WritableValue> {
+        [expression]
+    }
+
+    public static func buildBlock(_ components: [WritableValue]...) -> [WritableValue] {
+        Array(components.joined())
+    }
+
+    public static func buildEither<S: Sequence>(first component: S) -> S
+    where S.Element == WritableValue {
+        component
+    }
+
+    public static func buildEither<S: Sequence>(second component: S) -> S 
+    where S.Element == WritableValue {
+        component
+    }
+
+    public static func buildLimitedAvailability(_ component: [WritableValue]) -> [WritableValue] {
+        component
+    }
+
+    public static func buildArray(_ components: [[WritableValue]]) -> [WritableValue] {
+        Array(components.joined())
+    }
+}

--- a/Sources/BisonWrite/Values/WritableArray.swift
+++ b/Sources/BisonWrite/Values/WritableArray.swift
@@ -5,12 +5,44 @@
 //  Created by Christopher Richez on March 31 2022
 //
 
-/// A BSON document used exclusively for encoding.
+/// A BSON array document that can be written to a buffer.
+/// 
+/// Declare the structure of an array document as follows:
+///     
+///     // Pass a trailing closure to the initializer.
+///     let arrayDoc = WritableArray {
+///         // Declare values in the order they should appear.
+///         "zero"
+///         "one"
+///         // You can declare a value of any type conforming to `WritableValue`.
+///         2.0
+///         Int64(3)
+///         // Use conditionals.
+///         if !skipFour {
+///             4.0
+///         }
+///         // And loops.
+///         for number in Int32(5)..<100 {
+///             number
+///         }
+///     }
+/// 
+/// When ready to encode the composed document, call its `encode(as:)` method. You can provide
+/// any `RangeReplaceableCollection` of `UInt8` bytes. The example below encodes the document
+/// as `Data`, then writes it to a URL.
+/// 
+///     let encodedArrayDoc = arrayDoc.encode(as: Data.self)
+///     try encodedArrayDoc.write(to: path)
+/// 
 public struct WritableArray<Body: Sequence> where Body.Element == WritableValue {
-    /// The contents of this document.
+    /// The contents of this array, a sequence of type-erased writable values.
     let body: Body
     
-    /// Initializes a `Document` from the provided components.
+    /// Initializes an array document from the provided declaration.
+    /// 
+    /// - Parameter body: an `ArrayDocBuilder` closure declaring the structure of the array.
+    /// 
+    /// - Throws: Re-throws any errors thrown in the `body` closure.
     public init(@ArrayDocBuilder body: @escaping () throws -> Body) rethrows {
         self.body = try body()
     }
@@ -18,6 +50,8 @@ public struct WritableArray<Body: Sequence> where Body.Element == WritableValue 
     /// Encodes this BSON array document as the specified buffer type.
     /// 
     /// - Parameter type: a `RangeReplaceableCollection` to encode this document as
+    /// 
+    /// - Returns: An instance of the requested buffer type that contains the declared document.
     public func encode<Buffer>(as type: Buffer.Type) -> Buffer
     where Buffer : RangeReplaceableCollection, Buffer.Element == UInt8 {
         var buffer = Buffer()

--- a/Sources/BisonWrite/Values/WritableDoc.swift
+++ b/Sources/BisonWrite/Values/WritableDoc.swift
@@ -5,7 +5,32 @@
 //  Created by Christopher Richez on March 1 2022
 //
 
-/// A BSON document used exclusively for encoding.
+/// A BSON document that can be written to a buffer.
+/// 
+/// Declare the structure of a BSON document as follows:
+///     
+///     // Pass a trailing closure to the initializer.
+///     let doc = WritableDoc {
+///         // Assign String keys and WritableValues using the => operator
+///         "zero" => Int32(0)
+///         "one" => Int64(1)
+///         // Use conditionals
+///         if !skipTwo {
+///             "two" => 2.0
+///         }
+///         // And loops
+///         ForEach(Int64(3)..<100) { number in
+///             String(number) => number
+///         }
+///     }
+/// 
+/// When ready to encode the composed document, call its `encode(as:)` method. You can provide
+/// any `RangeReplaceableCollection` of `UInt8` bytes. The example below encodes the document
+/// as `Data`, then writes it to a URL.
+/// 
+///     let encodedDoc = doc.encode(as: Data.self)
+///     try encodedDoc.write(to: path)
+///
 public struct WritableDoc<Body: DocComponent> {
     /// The contents of this document.
     let body: Body

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -309,7 +309,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         let value = "passed?"
         let doc = WritableDoc {
             "test" => WritableArray {
-                "0" => value
+                value
             }
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -240,7 +240,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
     func testNestedContainer() throws {
         let value = Bool.random()
         let doc = WritableDoc { 
-            "0" => WritableArray {
+            "0" => WritableDoc {
                 "test" => value
             }
         }
@@ -254,7 +254,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
         let value = Bool.random()
         let doc = WritableDoc { 
             "0" => WritableArray {
-                "0" => value
+                value
             }
         }
         let parsedDoc = try ReadableDoc(bsonBytes: doc.bsonBytes)

--- a/Tests/BisonEncodeTests/BSONEncoderTests.swift
+++ b/Tests/BisonEncodeTests/BSONEncoderTests.swift
@@ -24,9 +24,9 @@ class BSONEncoderTests: XCTestCase {
             "name" => "test"
             "value" => 1.23
             "list" => WritableArray {
-                "0" => true
-                "1" => false
-                "2" => true
+                true
+                false
+                true
             }
         }
         let expectedBytes = Data(expectedDoc.bsonBytes)

--- a/Tests/BisonEncodeTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BisonEncodeTests/BSONKeyedEncodingContainerTests.swift
@@ -146,7 +146,7 @@ class BSONKeyedEncodingContainerTests: XCTestCase {
         try nestedContainer.encode(value)
         let expectedBytes = WritableDoc {
             "test" => WritableArray {
-                "0" => value
+                value
             }
         }
         .bsonBytes

--- a/Tests/BisonEncodeTests/BSONUnkeyedEncodingContainerTests.swift
+++ b/Tests/BisonEncodeTests/BSONUnkeyedEncodingContainerTests.swift
@@ -139,7 +139,7 @@ class BSONUnkeyedEncodingContainerTests: XCTestCase {
         try nestedContainer.encode(value)
         let expectedBytes = WritableDoc {
             "0" => WritableArray {
-                "0" => value
+                value
             }
         }
         .bsonBytes

--- a/Tests/BisonWriteTests/ArrayDocBuilderTests.swift
+++ b/Tests/BisonWriteTests/ArrayDocBuilderTests.swift
@@ -68,4 +68,50 @@ class WritableArrayBuilderTests: XCTestCase {
         .encode(as: [UInt8].self)
         XCTAssertEqual(encodedDoc, expectedDoc)
     }
+
+    /// Asserts blocks declared in control-flow branches are stitched at the appropriate index.
+    func testBlockStitching() {
+        let doc = WritableArray {
+            0.0
+            1.0
+            do {
+                2.0
+                3.0
+            }
+            4.0
+        }
+        .encode(as: [UInt8].self)
+        let expectedDoc = WritableDoc {
+            "0" => 0.0
+            "1" => 1.0
+            "2" => 2.0
+            "3" => 3.0
+            "4" => 4.0
+        }
+        .encode(as: [UInt8].self)
+        XCTAssertEqual(doc, expectedDoc)
+    }
+
+    /// Asserts nested documents are indexed as expected.
+    func testNestedDoc() {
+        let doc = WritableArray {
+            WritableArray {
+                "zero"
+            }
+            WritableArray {
+                "one"
+            }
+        }
+        .encode(as: Data.self)
+        let expectedDoc = WritableDoc {
+            "0" => WritableArray {
+                "zero"
+            }
+            "1" => WritableArray {
+                "one"
+            }
+        }
+        .encode(as: Data.self)
+        XCTAssertEqual(doc, expectedDoc)
+    }
 }

--- a/Tests/BisonWriteTests/ArrayDocBuilderTests.swift
+++ b/Tests/BisonWriteTests/ArrayDocBuilderTests.swift
@@ -1,0 +1,71 @@
+//
+//  WritableArrayBuilderTests.swift
+//
+//
+//  Created by Christopher Richez on July 29 2022.
+//
+
+@testable
+import BisonWrite
+import XCTest
+
+class WritableArrayBuilderTests: XCTestCase {
+    func testBuildBlock() {
+        let doc = WritableArray {
+            "zero"
+            "one"
+            "two"
+            "three"
+        }
+        var encodedDoc = [UInt8]()
+        doc.append(to: &encodedDoc)
+        let expectedDoc = WritableDoc {
+            "0" => "zero"
+            "1" => "one"
+            "2" => "two"
+            "3" => "three"
+        }
+        let expectedEncodedDoc = expectedDoc.encode(as: [UInt8].self)
+        XCTAssertEqual(encodedDoc, expectedEncodedDoc)
+    }
+
+    func testBuildEither() {
+        let skipTwo = true
+        let doc = WritableArray {
+            "zero"
+            "one"
+            if skipTwo {
+                "three"
+            } else {
+                "two"
+            }
+        }
+        var encodedDoc = [UInt8]()
+        doc.append(to: &encodedDoc)
+        let expectedDoc = WritableDoc {
+            "0" => "zero"
+            "1" => "one"
+            "2" => "three"
+        }
+        let expectedEncodedDoc = expectedDoc.encode(as: [UInt8].self)
+        XCTAssertEqual(encodedDoc, expectedEncodedDoc)
+    }
+
+    func testBuildArray() {
+        let numbers: Range<Int64> = 0..<100
+        let doc = WritableArray {
+            for number in numbers {
+                number
+            }
+        }
+        var encodedDoc = [UInt8]()
+        doc.append(to: &encodedDoc)
+        let expectedDoc = WritableDoc {
+            ForEach(numbers) { number in 
+                String(number) => number
+            }
+        }
+        .encode(as: [UInt8].self)
+        XCTAssertEqual(encodedDoc, expectedDoc)
+    }
+}


### PR DESCRIPTION
## Objectives

This pull request re-implements the `WritableArray` type using a new result builder tailor-made
to BSON array document composition, and closes #35. This exposes a more natural API when 
composing array documents, while preserving the existing string-keyed document composition API.

## Detailed Design

Note there is a significant additional performance cost to the proposed design. Since it relies
on `joined()` arrays of existential values, it suffers from numerous intermiediary allocations
and dynamic dispatch calls. This was favored due to the simplicity of the implementation for now,
and may change in the future. See the alternatives considered section for details.

### No More Indices

Array documents are now intialized by providing a list of WritableValues to the result builder
closure without explicitly declaring indices. The indices are calculated when the `encode(to:)`
method is called and the document hierarchy has already been flattened by the result builder.
The following example declares an array document with three different types, and a conditional 
statement.

```swift
let doc = WritableArray {
    "zero"
    Int32(1)
    if skipTwo {
        3.0
    } else {
        Int64(2)
    }
}
```

### Natural Heterogenous Loops

Previously, integer-keyed documents had to be manually composed using the `ForEach` type. Not only
did this require explicit index declaration, but it required all components in the loop to be of
the same type conforming to `WritableValue`, and did not accept existentials for performance 
reasons. The new loop API depends on existentials entirely, and therefore type-erases each value
for the caller. It also features a more natural loop expression using a swift `for` statement.

```swift
let collection: [WritableValue] = [Int64(0), "one", 2.0]
let doc = WritableArray {
    for value in collection {
        value
    }
}
```

## Alternatives Considered

These alternatives require technology currently in development.

### Partial Block Building

The new `buildPartialBlock` method in Swift 5.7 removes the need for the `TupleX` types used
by the current `DocBuilder` implementation and instead reduces each new component into the
previous one. This makes building more linear, and should allow for simple increment-based
index assignment. The following should be a working implementation, but I haven't tinkered with
the actual toolchain yet.

```swift
public protocol IndexedDocComponent: DocComponent {
    var lastIndex: Int { get }
}

struct First<T: WritableValue>: IndexedDocComponent {
    let value: T
    var lastIndex: Int { 0 }

    func append<Doc>(to document: inout Doc) 
    where Doc : RangeReplaceableCollection, Doc.Element == UInt8 {
        document.append(value.bsonType)
        document.append(contentsOf: String(lastIndex).utf8)
        document.append(0)
        value.append(to: &document)
    }
}

struct Tuple<T: IndexedDocComponent, V: WritableValue>: IndexedDocComponent {
    let previousTuple: T
    let nextValue: V
    var lastIndex: Int

    func append<Doc>(to document: inout Doc)
    where Doc : RangeReplaceableCollection, Doc.Element == UInt8 {
        previousTuple.append(to: &document)
        document.append(nextValue.bsonType)
        document.append(contentsOf: String(lastIndex).utf8)
        document.append(0)
        value.append(to: &document)
    }
}

@resultBuilder public struct ArrayDocBuilder {
    public static func buildPartialBlock<T: WritableValue>(
        first content: T
    ) -> some IndexedDocComponent {
        First(content)
    }

    public static func buildPartialBlock<T, Next>(
        accumulated: T, 
        next: Next
    ) -> some IndexedDocComponent where T : IndexedDocComponent, Next : WritableValue {
        Tuple(previousTuple: accumulated, nextValue: next, lastIndex: accumulated.lastIndex + 1)
    }
}
```

### Variadic Generics

Now that variadic generics have been accepted into the language, we are awaiting its implementation
to help out with this existential type problem. We should be able to make the `buildBlock(_:)`
method generic over a pack of types conforming to `WritableValue`. We can then iterate over the 
pack and append each key-value pair using an internally tracked index. This should be faster than
the `buildPartialBlock(accumulated:next:)` solution above, but I don't have a good concept of what
that would look like yet.
