### PR TITLE
Change license to Apache 2.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,51 @@
-MIT License
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
 
-Copyright (c) 2022 Christopher Richez
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without ålimitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/Sources/BisonDecode/BSONDecoder.swift
+++ b/Sources/BisonDecode/BSONDecoder.swift
@@ -1,8 +1,18 @@
 //
 //  BSONDecoder.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A type that decodes `Decodable` types from BSON documents.

--- a/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONKeyedDecodingContainer.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 4 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONSingleValueDecodingContainer.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 3 20222
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONUnkeyedDecodingContainer.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 5 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Sources/BisonDecode/DecodingContainerProvider.swift
+++ b/Sources/BisonDecode/DecodingContainerProvider.swift
@@ -1,8 +1,18 @@
 //
 //  DecodingContainerProvider.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Sources/BisonDecode/ParsedDocumentHelper.swift
+++ b/Sources/BisonDecode/ParsedDocumentHelper.swift
@@ -1,8 +1,18 @@
 //
-//  ReadableDocHelper.swift
+//  ParsedDocumentHelper.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Sources/BisonEncode/BSONEncoder.swift
+++ b/Sources/BisonEncode/BSONEncoder.swift
@@ -1,8 +1,18 @@
 //
 //  BSONEncoder.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonEncode/BSONEncodingContainerProvider.swift
+++ b/Sources/BisonEncode/BSONEncodingContainerProvider.swift
@@ -1,8 +1,18 @@
 //
-//  BSONContainerProvider.swift
+//  BSONEncodingContainerProvider.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Sources/BisonEncode/BSONKeyedEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONKeyedEncodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONKeyedEncodingContainer.swift
-//  BSONKeyedEncodingContainer
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 31 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Sources/BisonEncode/BSONSingleValueEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONSingleValueEncodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONSingleValueEncodingContainer.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 28 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Sources/BisonEncode/BSONUnkeyedEncodingContainer.swift
+++ b/Sources/BisonEncode/BSONUnkeyedEncodingContainer.swift
@@ -1,8 +1,18 @@
 //
 //  BSONUnkeyedEncodingContainer.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Sources/BisonEncode/ValueBox.swift
+++ b/Sources/BisonEncode/ValueBox.swift
@@ -1,8 +1,18 @@
 //
 //  ValueBox.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Sources/BisonRead/BisonError.swift
+++ b/Sources/BisonRead/BisonError.swift
@@ -1,8 +1,18 @@
 //
 //  BisonError.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 16 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// An error that occured while parsing a BSON value.

--- a/Sources/BisonRead/CustomReadableValue.swift
+++ b/Sources/BisonRead/CustomReadableValue.swift
@@ -1,8 +1,18 @@
 //
 //  CustomReadableValue.swift
-//  
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 4/28/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A BSON value whose encoded form declares the BSON binary type (5).

--- a/Sources/BisonRead/Data+CustomReadableValue.swift
+++ b/Sources/BisonRead/Data+CustomReadableValue.swift
@@ -1,8 +1,18 @@
 //
-//  Data+ReadableValue.swift
-//  
+//  Data+CustomReadableValue.swift
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 4/28/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonRead/Date+ReadableValue.swift
+++ b/Sources/BisonRead/Date+ReadableValue.swift
@@ -1,8 +1,18 @@
 //
 //  Date+ReadableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on May 26, 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonRead/ObjectID+ReadableValue.swift
+++ b/Sources/BisonRead/ObjectID+ReadableValue.swift
@@ -1,8 +1,18 @@
 //
 //  ObjectID+ReadableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 16 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import ObjectID

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -1,8 +1,18 @@
 //
 //  ReadableDoc.swift
-//  ReadableDoc
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 4th 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import OrderedCollections

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -1,8 +1,18 @@
 //
 //  ReadableValue.swift
-//  ReadableValue
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 4 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A value that can be parsed from its encoded BSON representation.

--- a/Sources/BisonRead/UUID+CustomReadableValue.swift
+++ b/Sources/BisonRead/UUID+CustomReadableValue.swift
@@ -1,8 +1,18 @@
 //
-//  File.swift
-//  
+//  UUID+CustomReadableValue.swift
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 4/28/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonWrite/Components/AssignmentOperator.swift
+++ b/Sources/BisonWrite/Components/AssignmentOperator.swift
@@ -1,8 +1,18 @@
 //
-//  =>.swift
-//  
+//  AssignmentOperator.swift
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 3/16/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// An operator used to assign a BSON `String` key to a `WritableValue` conforming value.

--- a/Sources/BisonWrite/Components/DocComponent.swift
+++ b/Sources/BisonWrite/Components/DocComponent.swift
@@ -1,8 +1,18 @@
 //
 //  DocComponent.swift
-//  DocComponent
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 1 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A basic building block of a BSON document.

--- a/Sources/BisonWrite/Components/ForEach.swift
+++ b/Sources/BisonWrite/Components/ForEach.swift
@@ -1,8 +1,18 @@
 //
 //  ForEach.swift
-//  ForEach
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 1 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// Encodes a sequence into a document using the provided closure.

--- a/Sources/BisonWrite/Components/Group.swift
+++ b/Sources/BisonWrite/Components/Group.swift
@@ -1,8 +1,18 @@
 //
 //  Group.swift
-//  Group
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 1 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A group of document components values.

--- a/Sources/BisonWrite/Components/OptionalComponent.swift
+++ b/Sources/BisonWrite/Components/OptionalComponent.swift
@@ -1,8 +1,18 @@
 //
 //  OptionalComponent.swift
-//  OptionalComponent
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 16 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A wrapper type for an optional component used exclusively by ``DocBuilder/buildOptional(_:)``.

--- a/Sources/BisonWrite/Components/Pair.swift
+++ b/Sources/BisonWrite/Components/Pair.swift
@@ -1,8 +1,18 @@
 //
 //  Pair.swift
-//  Pair
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 1 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A key-value pair used to compose a BSON document.

--- a/Sources/BisonWrite/DocBuilder.swift
+++ b/Sources/BisonWrite/DocBuilder.swift
@@ -1,8 +1,18 @@
 //
 //  DocBuilder.swift
-//  DocBuilder
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 16 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @resultBuilder

--- a/Sources/BisonWrite/Tuples/Tuple+DocComponent.swift
+++ b/Sources/BisonWrite/Tuples/Tuple+DocComponent.swift
@@ -1,8 +1,18 @@
 //
 //  Tuple+DocComponent.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 15 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 extension Tuple2: DocComponent where T0: DocComponent, T1: DocComponent {

--- a/Sources/BisonWrite/Tuples/Tuple.swift
+++ b/Sources/BisonWrite/Tuples/Tuple.swift
@@ -1,8 +1,18 @@
 //
 //  Tuples.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on February 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 struct Tuple2<T0, T1> {

--- a/Sources/BisonWrite/Values/CustomWritableValue.swift
+++ b/Sources/BisonWrite/Values/CustomWritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  CustomWritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A BSON value that declares the `binary` type (5).

--- a/Sources/BisonWrite/Values/Data+WritableValue.swift
+++ b/Sources/BisonWrite/Values/Data+WritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  Data+WritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonWrite/Values/Date+WritableValue.swift
+++ b/Sources/BisonWrite/Values/Date+WritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  Date+WritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on May 26 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonWrite/Values/ObjectID+WritableValue.swift
+++ b/Sources/BisonWrite/Values/ObjectID+WritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  ObjectID+WritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 16 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import ObjectID

--- a/Sources/BisonWrite/Values/UUID+WritableValue.swift
+++ b/Sources/BisonWrite/Values/UUID+WritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  UUID+WritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Sources/BisonWrite/Values/WritableArray.swift
+++ b/Sources/BisonWrite/Values/WritableArray.swift
@@ -1,8 +1,18 @@
 //
 //  WritableArray.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A BSON document used exclusively for encoding.

--- a/Sources/BisonWrite/Values/WritableDoc.swift
+++ b/Sources/BisonWrite/Values/WritableDoc.swift
@@ -1,8 +1,18 @@
 //
 //  WritableDoc.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 1 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A BSON document used exclusively for encoding.

--- a/Sources/BisonWrite/Values/WritableValue.swift
+++ b/Sources/BisonWrite/Values/WritableValue.swift
@@ -1,8 +1,18 @@
 //
 //  WritableValue.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on 2/6/22.
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 /// A value that can be assigned to a ``Pair`` in a BSON document.

--- a/Sources/ObjectID/ObjectID.swift
+++ b/Sources/ObjectID/ObjectID.swift
@@ -1,8 +1,18 @@
 //
 //  ObjectID.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Tests/BisonDecodeTests/BSONDecoderTests.swift
+++ b/Tests/BisonDecodeTests/BSONDecoderTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONDecoderTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonDecode

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONKeyedDecodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 4 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONSingleValueDecodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 3 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONUnkeyedDecodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 5 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonDecodeTests/DecodingContainerProvoder.swift
+++ b/Tests/BisonDecodeTests/DecodingContainerProvoder.swift
@@ -1,8 +1,18 @@
 //
 //  DecodingContainerProvider.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 11 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonEncodeTests/BSONEncoderTests.swift
+++ b/Tests/BisonEncodeTests/BSONEncoderTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONEncoderTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonEncode

--- a/Tests/BisonEncodeTests/BSONKeyedEncodingContainerTests.swift
+++ b/Tests/BisonEncodeTests/BSONKeyedEncodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
-// BSONKeyedEncodingContainerTests.swift
+//  BSONKeyedEncodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonEncodeTests/BSONSingleValueEncodingContainerTests.swift
+++ b/Tests/BisonEncodeTests/BSONSingleValueEncodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONSingleValueEncodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 28th 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonEncodeTests/BSONUnkeyedEncodingContainerTests.swift
+++ b/Tests/BisonEncodeTests/BSONUnkeyedEncodingContainerTests.swift
@@ -1,8 +1,18 @@
 //
 //  BSONUnkeyedEncodingContainerTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on March 31 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonReadTests/CustomReadableValueTests.swift
+++ b/Tests/BisonReadTests/CustomReadableValueTests.swift
@@ -1,8 +1,18 @@
 //
 //  CustomReadableValueTests.swift
-//  
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 4/28/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import Foundation

--- a/Tests/BisonReadTests/ReadableDocTests.swift
+++ b/Tests/BisonReadTests/ReadableDocTests.swift
@@ -1,8 +1,18 @@
 //
 //  ReadableDocTests.swift
-//  ReadableDocTests
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 5 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable 

--- a/Tests/BisonReadTests/ReadableValueTests.swift
+++ b/Tests/BisonReadTests/ReadableValueTests.swift
@@ -1,8 +1,18 @@
 //
 //  ReadableValueTests.swift
-//  ReadableValueTests
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 20 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonRead

--- a/Tests/BisonWriteTests/CustomWritableValueTests.swift
+++ b/Tests/BisonWriteTests/CustomWritableValueTests.swift
@@ -1,8 +1,18 @@
 //
 //  CustomWritableValueTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Tests/BisonWriteTests/DocBuilderTests.swift
+++ b/Tests/BisonWriteTests/DocBuilderTests.swift
@@ -1,8 +1,18 @@
 //
 //  DocBuilderTests.swift
-//  
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on 2/6/22.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Tests/BisonWriteTests/DocComponentTests.swift
+++ b/Tests/BisonWriteTests/DocComponentTests.swift
@@ -1,8 +1,18 @@
 //
 //  DocComponentTests.swift
-//  DocComponentTests
+//  Copyright 2022 Christopher Richez
 //
-//  Created by Christopher Richez on March 17 2022
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 @testable

--- a/Tests/BisonWriteTests/WritableValueTests.swift
+++ b/Tests/BisonWriteTests/WritableValueTests.swift
@@ -1,8 +1,18 @@
 //
 //  WritableValueTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on 3/16/22.
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import BisonWrite

--- a/Tests/ObjectIDTests/ObjectIDTests.swift
+++ b/Tests/ObjectIDTests/ObjectIDTests.swift
@@ -1,8 +1,18 @@
 //
 //  ObjectIDTests.swift
+//  Copyright 2022 Christopher Richez
 //
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-//  Created by Christopher Richez on April 14 2022
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 import ObjectID


### PR DESCRIPTION
### Objectives

This pull request changes the `license.md` file to the Apache 2.0 license, and adds license notices to all files contained in `/Sources` and `/Tests`.
