### PR TITLE
Simplify parsing error catch statements

### DIFF
--- a/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
@@ -63,19 +63,19 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
             let decodedValue = try type.init(bsonBytes: valueData)
             codingPath.append(key)
             return decodedValue
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -89,19 +89,19 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
             let decodedValue = try type.init(bsonBytes: valueData)
             codingPath.append(key)
             return decodedValue as! T
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -184,7 +184,7 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
     }
 
     /// The error expected from parsing a nested keyed document.
-    private typealias NestedDocError = ReadableDoc<Data.SubSequence>.Error
+    private typealias NestedDocError = DocError<Data.SubSequence>
 
     func nestedContainer<NestedKey: CodingKey>(
         keyedBy type: NestedKey.Type, 

--- a/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
@@ -33,21 +33,21 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
     private func read<T: ReadableValue>(_ type: T.Type) throws -> T {
         do {
             return try type.init(bsonBytes: contents)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least \(needAtLeast) bytes for a \(type), but found \(contents.count)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected \(need) bytes for a \(type), but found \(contents.count)
                 """,
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -59,19 +59,19 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
         do {
             let decodedValue = try type.init(bsonBytes: contents)
             return decodedValue as! T
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
              let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }

--- a/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
@@ -82,21 +82,21 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         let encodedValue = try nextValueData()
         do {
             return try type.init(bsonBytes: encodedValue)
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: """
                     expected \(need) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath,
                 debugDescription: """
                     expected at least \(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -109,19 +109,19 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
         do {
             let decodedValue = try type.init(bsonBytes: valueData)
             return decodedValue as! T
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: BisonError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(need, have))
             throw DecodingError.typeMismatch(type, context)
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: BisonError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast, have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -198,7 +198,7 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
     }
 
     /// The error expected from parsing a nested keyed document.
-    private typealias NestedDocError = ReadableDoc<Data.SubSequence>.Error
+    private typealias NestedDocError = DocError<Data.SubSequence>
 
     mutating func nestedContainer<NestedKey: CodingKey>(
         keyedBy type: NestedKey.Type

--- a/Sources/BisonDecode/DecodingContainerProvider.swift
+++ b/Sources/BisonDecode/DecodingContainerProvider.swift
@@ -36,7 +36,7 @@ struct DecodingContainerProvider<Data: Collection> where Data.Element == UInt8 {
 }
 
 extension DecodingContainerProvider: Decoder {
-    private typealias NestedDocError = ReadableDoc<Data>.Error
+    private typealias NestedDocError = DocError<Data>
 
     func container<Key: CodingKey>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
         let doc = try ReadableDoc(

--- a/Sources/BisonDecode/ParsedDocumentHelper.swift
+++ b/Sources/BisonDecode/ParsedDocumentHelper.swift
@@ -22,39 +22,39 @@ extension ReadableDoc {
     init(decoding data: Data, codingPath: [CodingKey], for type: Any.Type) throws {
         do {
             try self.init(bsonBytes: data)
-        } catch Error.docTooShort {
+        } catch DocError<Data>.docTooShort {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     expected at least 5 bytes for a document, but found \(data.count)
                 """,
-                underlyingError: Error.docTooShort)
+                underlyingError: DocError<Data>.docTooShort)
             throw DecodingError.typeMismatch(type, context)
-        } catch Error.notTerminated {
+        } catch DocError<Data>.notTerminated {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected a null byte at the end of the document",
-                underlyingError: Error.notTerminated)
+                underlyingError: DocError<Data>.notTerminated)
             throw DecodingError.dataCorrupted(context)
-        } catch Error.docSizeMismatch(let declared) {
+        } catch DocError<Data>.docSizeMismatch(let declared) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: """
                     declared document size is \(declared) but actual size is \(data.count)
                 """,
-                underlyingError: Error.docSizeMismatch(declared))
+                underlyingError: DocError<Data>.docSizeMismatch(declared))
             throw DecodingError.typeMismatch(type, context)
-        } catch Error.unknownType(let type, let key, let progress) {
+        } catch DocError<Data>.unknownType(let type, let key, let progress) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "key \"\(key)\" has unknown type byte \(type)", 
-                underlyingError: Error.unknownType(type, key, progress))
+                underlyingError: DocError<Data>.unknownType(type, key, progress))
             throw DecodingError.dataCorrupted(context)
-        } catch Error.valueSizeMismatch(let need, let key, let progress) {
+        } catch DocError<Data>.valueSizeMismatch(let need, let key, let progress) {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected at least \(need) bytes for value \"\(key)\"",
-                underlyingError: Error.valueSizeMismatch(need, key, progress))
+                underlyingError: DocError<Data>.valueSizeMismatch(need, key, progress))
             throw DecodingError.dataCorrupted(context)
         }
     }

--- a/Sources/BisonRead/CustomReadableValue.swift
+++ b/Sources/BisonRead/CustomReadableValue.swift
@@ -23,16 +23,16 @@ public protocol CustomReadableValue: ReadableValue {
     ///
     /// - Parameter bsonValueBytes: the value's encoded bytes, not including size and subtype bytes
     ///
-    /// - Throws: The appropriate ``BisonError``.
+    /// - Throws: The appropriate ``ValueError``.
     init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8
 }
 
 extension CustomReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count >= 5 else { throw BisonError.dataTooShort(5, data.count) }
+        guard data.count >= 5 else { throw ValueError.dataTooShort(5, data.count) }
         let declaredSize = Int(truncatingIfNeeded: try Int32(bsonBytes: data.prefix(4)))
         guard data.count == declaredSize + 5 else {
-            throw BisonError.sizeMismatch(declaredSize + 5, data.count)
+            throw ValueError.sizeMismatch(declaredSize + 5, data.count)
         }
         try self.init(bsonValueBytes: data.dropFirst(5))
     }

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -1,0 +1,106 @@
+//
+//  DocError.swift
+//  Copyright 2022 Christopher Richez
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/// An error that occured while reading a BSON document.
+/// 
+/// ## Catching Document Parsing Errors
+/// 
+/// `DocError` is generic over the collection type the document was read from, just like
+/// ``ReadableDoc``. This allows select errors to provide partially decoded documents and more
+/// detailed debugging information.
+/// 
+/// To handle a `DocError`, include the document's collection type in your `catch` statement.
+/// 
+/// ```swift
+/// do {
+///     // Here the document is read from `Foundation.Data`
+///     let encodedDoc = try Data(contentsOf: url)
+///     let decodedDoc = try ReadableDoc(bsonBytes: encodedDoc)
+/// } catch DocError<Data>.docTooShort {
+///     // A trivial error with no partial success
+/// } catch DocError<Data>.unknownType(let type, let key, let progress) {
+///     // An error that reports achieved progress, perhaps recoverable
+/// }
+/// ```
+public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
+    /// Less than 5 bytes were passed to the initializer.
+    /// 
+    /// BSON documents will always be 5 or more bytes long to include the size and null-terminator.
+    /// In most cases this error means the expected data wasn't loaded into the buffer, or isn't a 
+    /// valid BSON document.
+    /// 
+    /// > Note: This error is triggered before ``notTerminated``, even if the data also isn't
+    ///   properly null-terminated.
+    case docTooShort
+
+    /// The data passed to the initializer was not null-terminated.
+    /// 
+    /// Parsing an otherwise valid BSON document that isn't properly null-terminated may cause 
+    /// out-of-bounds errors and crashes while reading keys, and isn't supported. In most cases,
+    /// this error means the data was corrupted in transit or isn't a valid BSON document.
+    case notTerminated
+
+    /// The declared size of the document does not match the size of the data passed to the
+    /// initializer.
+    /// 
+    /// The declared size of the document is attached to the error, and can be compared against
+    /// the encoded document's `count` property for debugging. In most cases, this error means
+    /// the data was corrupted in transit or isn't a valid BSON document.
+    /// 
+    /// > Note: In the case of corruption, ``notTerminated`` will usually be triggered first.
+    ///   There is a chance that the corrupted data happens to be null-terminated, in whcih case
+    ///   this error may be triggered instead.
+    case docSizeMismatch(_ expectedExactly: Int)
+
+    /// An unknown or deprecated BSON type byte was found while parsing a key.
+    /// 
+    /// This error includes a ``Progress`` value. You may check the partially decoded document
+    /// within to recover from the error.
+    case unknownType(_ type: UInt8, _ key: String, _ progress: Progress<Data>)
+
+    /// There were not enough bytes left in the document to parse the next expected value.
+    /// 
+    /// This error includes a ``Progress`` value. You may check the partially decoded document
+    /// within to recover from the error.
+    case valueSizeMismatch(_ needAtLeast: Int, _ key: String, _ progress: Progress<Data>)
+}
+
+/// The parsed and un-parsed parts of a document after an error occured.
+public struct Progress<Data: Collection> where Data.Element == UInt8 {
+    /// A ``ReadableDoc`` that contains all successfully parsed key-value pairs.
+    public let parsed: ReadableDoc<Data>
+
+    /// The remaining unparsed data after the error occured.
+    public let remaining: Data.SubSequence
+}
+
+extension Progress: Equatable where Data.SubSequence : Equatable {
+    // This conformance is inherited from `Data.SubSequence`.
+}
+
+extension DocError: Equatable where Data.SubSequence : Equatable {
+    // This conformance is inherited from `Progress`.
+}
+
+extension Progress: Hashable where Data.SubSequence : Hashable {
+    // This conformance is inherited from `Data.SubSequence`.
+}
+
+extension DocError: Hashable where Data.SubSequence : Hashable {
+    // This conformance is inherited from `Progress`.
+}
+

--- a/Sources/BisonRead/ObjectID+ReadableValue.swift
+++ b/Sources/BisonRead/ObjectID+ReadableValue.swift
@@ -19,7 +19,7 @@ import ObjectID
 
 extension ObjectID: ReadableValue {
     public init<Data>(bsonBytes data: Data) throws where Data : Collection, Data.Element == UInt8 {
-        guard data.count == 12 else { throw BisonError.sizeMismatch(12, data.count) }
+        guard data.count == 12 else { throw ValueError.sizeMismatch(12, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 12, alignment: 1)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: ObjectID.self)

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -22,13 +22,13 @@ public protocol ReadableValue {
     /// - Parameter data: the encoded value, usually returned by the `ReadableDoc` subscript
     /// 
     /// - Throws:
-    /// A `BisonError` appropriate for the type to initialize.
+    /// A `ValueError` appropriate for the type to initialize.
     init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8
 }
 
 extension Int32: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 4 else { throw BisonError.sizeMismatch(4, data.count) }
+        guard data.count == 4 else { throw ValueError.sizeMismatch(4, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 4)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int32.self)
@@ -37,7 +37,7 @@ extension Int32: ReadableValue {
 
 extension Int64: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw BisonError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int64.self)
@@ -46,7 +46,7 @@ extension Int64: ReadableValue {
 
 extension UInt64: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw BisonError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: UInt64.self)
@@ -55,7 +55,7 @@ extension UInt64: ReadableValue {
 
 extension Double: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw BisonError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Double.self)
@@ -64,20 +64,20 @@ extension Double: ReadableValue {
 
 extension Bool: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 1 else { throw BisonError.sizeMismatch(1, data.count) }
+        guard data.count == 1 else { throw ValueError.sizeMismatch(1, data.count) }
         self = data[data.startIndex] == 0 ? false : true
     }
 }
 
 extension String: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count > 4 else { throw BisonError.dataTooShort(5, data.count) }
+        guard data.count > 4 else { throw ValueError.dataTooShort(5, data.count) }
         let sizeStart = data.startIndex
         let sizeEnd = data.index(sizeStart, offsetBy: 4)
         // We try! here since we already ensured we have four bytes to read
         let size = Int(try! Int32(bsonBytes: data[sizeStart..<sizeEnd]))
         guard data.count == size + 4 else { 
-            throw BisonError.sizeMismatch(size + 4, data.count) 
+            throw ValueError.sizeMismatch(size + 4, data.count) 
         }
         self.init(decoding: data[sizeEnd..<data.index(data.endIndex, offsetBy: -1)], as: UTF8.self)
     }

--- a/Sources/BisonRead/UUID+CustomReadableValue.swift
+++ b/Sources/BisonRead/UUID+CustomReadableValue.swift
@@ -20,7 +20,7 @@ import Foundation
 extension UUID: CustomReadableValue {
     public init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8 {
         guard bsonValueBytes.count == 16 else {
-            throw BisonError.sizeMismatch(16, bsonValueBytes.count)
+            throw ValueError.sizeMismatch(16, bsonValueBytes.count)
         }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 16, alignment: 1)
         copyBuffer.copyBytes(from: bsonValueBytes)

--- a/Sources/BisonRead/ValueError.swift
+++ b/Sources/BisonRead/ValueError.swift
@@ -1,5 +1,5 @@
 //
-//  BisonError.swift
+//  ValueError.swift
 //  Copyright 2022 Christopher Richez
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 //
 
 /// An error that occured while parsing a BSON value.
-public enum BisonError: Error, Equatable {
+public enum ValueError: Error, Equatable {
     /// The data passed to the initializer was shorter than the required metadata for this value.
     /// 
     /// This case provides the expected and actual size of the data passed to the initializer.

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -93,10 +93,10 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                BisonError.sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Int32>.size))
+                ValueError.sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Int32>.size))
         }
     }
 
@@ -121,7 +121,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Int32>.size))
         }
     }
@@ -138,7 +138,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(underlyingError, .sizeMismatch(6, 8))
         }
     }
@@ -164,7 +164,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<UInt64>.size))
@@ -193,7 +193,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<UInt64>.size))
@@ -222,7 +222,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
@@ -251,7 +251,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attempted, let context) {
             XCTAssert(attempted == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))
@@ -309,7 +309,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == KeyedDecodingContainer<Key>.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = context.underlyingError 
-                as? ReadableDoc<Array<UInt8>.SubSequence>.Error
+                as? DocError<Array<UInt8>.SubSequence>
             let unwrappedError = try XCTUnwrap(underlyingError)
             XCTAssertEqual(unwrappedError, .docTooShort)
         }

--- a/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
@@ -47,7 +47,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Bool>.size, container.contents.count))
@@ -70,7 +70,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Double>.size, container.contents.count))
@@ -93,7 +93,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .dataTooShort(5, container.contents.count))
@@ -110,7 +110,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(13, container.contents.count))
@@ -133,7 +133,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int32>.size, container.contents.count))
@@ -156,7 +156,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<UInt64>.size, container.contents.count))
@@ -179,7 +179,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
         } catch DecodingError.typeMismatch(let attemptedType, let context) {
             XCTAssert(attemptedType == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
-            let underlyingError = try XCTUnwrap(context.underlyingError as? BisonError)
+            let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int64>.size, container.contents.count))

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -64,7 +64,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Double.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Bool>.size))
@@ -91,7 +91,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Bool>.size))
         }
     }
@@ -108,7 +108,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(underlyingError, .sizeMismatch(13, MemoryLayout<Int64>.size))
         }
     }
@@ -133,7 +133,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Bool.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<Double>.size))
@@ -160,7 +160,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Int32.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<Double>.size))
@@ -187,7 +187,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == Int64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
@@ -214,7 +214,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == UInt64.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
-                context.underlyingError as? BisonError)
+                context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
                 .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))

--- a/Tests/BisonReadTests/ReadableDocTests.swift
+++ b/Tests/BisonReadTests/ReadableDocTests.swift
@@ -50,25 +50,25 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts attempting to parse a document from less than 5 bytes throws 
-    /// `ReadableDoc<_>.Error.docTooShort`.
+    /// `DocError<_>.docTooShort`.
     func testDocDataTooShort() throws {
         let faultyBytes: [UInt8] = [4, 0, 0, 0]
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch ReadableDoc<[UInt8]>.Error.docTooShort {
+        } catch DocError<[UInt8]>.docTooShort {
             // This is expected
         }
     }
 
     /// Asserts attempting to parse a document from non null-terminated data throws
-    /// `ReadableDoc<_>.Error.notTerminated`.
+    /// `DocError<_>.notTerminated`.
     func testDocDataNotTerminated() throws {
         let faultyBytes: [UInt8] = [10] + [UInt8](repeating: 1, count: 9)
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch ReadableDoc<[UInt8]>.Error.notTerminated {
+        } catch DocError<[UInt8]>.notTerminated {
             // This is expected
         }
     }
@@ -80,13 +80,13 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             XCTAssertEqual(error, .docSizeMismatch(3))
         }
     }
 
     /// Asserts attempting to parse a document with a non-specification type throws 
-    /// `ReadableDoc<_>.Error.unknownType` with the expected attached values.
+    /// `DocError<_>.unknownType` with the expected attached values.
     func testUnknownType() throws {
         let faultyBytes: [UInt8] = [
             /* size: */ 10, 0, 0, 0, 
@@ -96,9 +96,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>(["": faultyBytes[6...6]])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[7...])
             XCTAssertEqual(error, .unknownType(100, "", progress))
@@ -106,7 +106,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts parsing a document with a value truncated to less than its expected number of bytes
-    /// throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected attached values.
+    /// throws `DocError<_>.valueSizeMismatch` with the expected attached values.
     /// 
     /// This test uses `Double` as its fixed-size type of choice. The logic is the same for other
     /// fixed-size types, so this test satisfies those requirements as well.
@@ -120,9 +120,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(8, "", progress))
@@ -143,9 +143,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
@@ -153,7 +153,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts parsing a document with a `String` value less than 5 bytes long throws
-    /// `ReadableDoc<_>.Error.valueSizeMismatch` with the expected attached values.
+    /// `DocError<_>.valueSizeMismatch` with the expected attached values.
     func testStringTooShort() throws {
         let faultyBytes: [UInt8] = [
             /* size: */ 10, 0, 0, 0, 
@@ -164,9 +164,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
                 XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
@@ -174,7 +174,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts parsing a document with a `String` value shorter than its declared size
-    /// throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected attached values.
+    /// throws `DocError<_>.valueSizeMismatch` with the expected attached values.
     func testStringSizeMismatch() throws {
         let faultyBytes: [UInt8] = [
             /* size: */ 15, 0, 0, 0,
@@ -186,9 +186,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(14, "", progress))
@@ -196,7 +196,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts decoding a document that declares a nested document but offers less than 5 
-    /// remaining bytes throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected
+    /// remaining bytes throws `DocError<_>.valueSizeMismatch` with the expected
     /// attached values.
     func testDocValueDataTooShort() throws {
         let faultyBytes: [UInt8] = [
@@ -208,9 +208,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
@@ -218,7 +218,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts decoding a document that declares a nested document but offers fewer bytes left
-    /// than are declared throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected
+    /// than are declared throws `DocError<_>.valueSizeMismatch` with the expected
     /// attached values.
     func testDocValueSizeMismatch() throws {
         let faultyBytes: [UInt8] = [
@@ -230,9 +230,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(10, "", progress))
@@ -240,7 +240,7 @@ class ReadableDocTests: XCTestCase {
     }
     
     /// Asserts decoding a document that declares a binary value but offers fewer than 5 bytes
-    /// left throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected attached values.
+    /// left throws `DocError<_>.valueSizeMismatch` with the expected attached values.
     func testBinaryValueDataTooShort() throws {
         let faultyBytes: [UInt8] = [
             /* size: */ 10, 0, 0, 0,
@@ -251,9 +251,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
@@ -261,7 +261,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts decoding a document that declares a binary value but offers fewer bytes left
-    /// than declared throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected
+    /// than declared throws `DocError<_>.valueSizeMismatch` with the expected
     /// attached values.
     func testBinaryValueSizeMismatch() throws {
         let faultyBytes: [UInt8] = [
@@ -274,9 +274,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(15, "", progress))
@@ -284,7 +284,7 @@ class ReadableDocTests: XCTestCase {
     }
 
     /// Asserts parsing a document with a regular expression value that doesn't contain a zero
-    /// throws `ReadableDoc<_>.Error.valueSizeMismatch` with the expected attached values.
+    /// throws `DocError<_>.valueSizeMismatch` with the expected attached values.
     func testRegularExpressionSizeMismatch() throws {
         let faultyBytes: [UInt8] = [
             /* size: */ 11, 0, 0, 0,
@@ -295,9 +295,9 @@ class ReadableDocTests: XCTestCase {
         do {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
-        } catch let error as ReadableDoc<[UInt8]>.Error {
+        } catch let error as DocError<[UInt8]> {
             let partialDoc = ReadableDoc<[UInt8]>([:])
-            let progress = ReadableDoc<[UInt8]>.Progress(
+            let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
             XCTAssertEqual(error, .valueSizeMismatch(6, "", progress))

--- a/Tests/BisonReadTests/ReadableValueTests.swift
+++ b/Tests/BisonReadTests/ReadableValueTests.swift
@@ -37,7 +37,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try Double(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, MemoryLayout<Double>.size)
             XCTAssertEqual(have, faultyBytes.count)
         }
@@ -59,7 +59,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try String(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.dataTooShort(let needAtLeast, let have) {
+        } catch ValueError.dataTooShort(let needAtLeast, let have) {
             XCTAssertEqual(needAtLeast, 5)
             XCTAssertEqual(have, faultyBytes.count)
         }
@@ -74,7 +74,7 @@ class ReadableValueTests: XCTestCase {
             encodedValue.replaceSubrange(0..<4, with: Int32(100).bsonBytes)
             let decodedValue = try String(bsonBytes: encodedValue)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, 104)
             XCTAssertEqual(have, encodedValue.count)
         }
@@ -96,7 +96,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try Bool(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, MemoryLayout<Bool>.size)
             XCTAssertEqual(have, faultyBytes.count)
         }
@@ -118,7 +118,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try Int32(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, MemoryLayout<Int32>.size)
             XCTAssertEqual(have, faultyBytes.count)
         }
@@ -140,7 +140,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try UInt64(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, MemoryLayout<UInt64>.size)
             XCTAssertEqual(have, faultyBytes.count)
         }
@@ -162,7 +162,7 @@ class ReadableValueTests: XCTestCase {
         do {
             let decodedValue = try Int64(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedValue)")
-        } catch BisonError.sizeMismatch(let need, let have) {
+        } catch ValueError.sizeMismatch(let need, let have) {
             XCTAssertEqual(need, MemoryLayout<Int64>.size)
             XCTAssertEqual(have, faultyBytes.count)
         }


### PR DESCRIPTION
## Objectives

This pull request improves `ReadableDoc` error handing UX.

## Detailed Design

Previously, handling errors emitted by `ReadableDoc.init(bsonBytes:)` was cumbersome due to the error type residing in the namespace of the document type, which itself is generic.

```swift
do {
    let doc = try ReadableDoc(bsonBytes: data)
} catch ReadableDoc<Data>.Error.docTooShort {
    // Error handling
}
```

The previous error type was moved out of its parent namespace and into the top-level namespace for the module. It is now also generic, but over the same constraints as its previous parent. Catch statements are now shorter and broadcast a little less noise.

```swift
do {
    let doc = try ReadableDoc(bsonBytes: data)
} catch DocError<Data>.docTooShort {
    // Error handling
}
```

## Alternatives Considered

The original design was chosen under the false pretense that the error type must be nested in order to inherit the same generic constraints as the parent type. This simply isn't true, the new design simply needs one more explicit generic declaration than the old one at the `throw` point.

There was also a motivation early in the project to have each `ReadableValue` expose its own error type in the hope that callers would know exactly which errors to handle and which to ignore. This approach included a lot of code duplication and fell out of favor as a result.
