### PR TITLE
Add argument labels to all error types

### DIFF
--- a/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
@@ -67,7 +67,7 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
@@ -93,7 +93,7 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(

--- a/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONKeyedDecodingContainer.swift
@@ -75,7 +75,7 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -101,7 +101,7 @@ extension BSONKeyedDecodingContainer: KeyedDecodingContainerProtocol {
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }

--- a/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
@@ -39,7 +39,7 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
                 debugDescription: """
                     expected at least \(needAtLeast) bytes for a \(type), but found \(contents.count)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.sizeMismatch(let need, let have) {
             let context = DecodingError.Context(
@@ -71,7 +71,7 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }

--- a/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONSingleValueDecodingContainer.swift
@@ -47,7 +47,7 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
                 debugDescription: """
                     expected \(need) bytes for a \(type), but found \(contents.count)
                 """,
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -63,7 +63,7 @@ extension BSONSingleValueDecodingContainer: SingleValueDecodingContainer {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.dataTooShort(let needAtLeast, let have) {
              let context = DecodingError.Context(

--- a/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
@@ -96,7 +96,7 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 debugDescription: """
                     expected at least \(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }
@@ -121,7 +121,7 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 debugDescription: """
                     expected at least\(needAtLeast) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.dataTooShort(needAtLeast, have))
+                underlyingError: ValueError.dataTooShort(needAtLeast: needAtLeast, found: have))
             throw DecodingError.typeMismatch(type, context)
         }
     }

--- a/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
+++ b/Sources/BisonDecode/BSONUnkeyedDecodingContainer.swift
@@ -88,7 +88,7 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
                 debugDescription: """
                     expected \(need) bytes for a \(type) but found \(have)
                 """,
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(
@@ -113,7 +113,7 @@ extension BSONUnkeyedDecodingContainer: UnkeyedDecodingContainer {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected \(need) bytes for a \(type) but found \(have)",
-                underlyingError: ValueError.sizeMismatch(need, have))
+                underlyingError: ValueError.sizeMismatch(expected: need, have: have))
             throw DecodingError.typeMismatch(type, context)
         } catch ValueError.dataTooShort(let needAtLeast, let have) {
             let context = DecodingError.Context(

--- a/Sources/BisonDecode/ParsedDocumentHelper.swift
+++ b/Sources/BisonDecode/ParsedDocumentHelper.swift
@@ -57,7 +57,10 @@ extension ReadableDoc {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "expected at least \(need) bytes for value \"\(key)\"",
-                underlyingError: DocError<Data>.valueSizeMismatch(need, key, progress))
+                underlyingError: DocError<Data>.valueSizeMismatch(
+                    needAtLeast: need, 
+                    key: key, 
+                    progress: progress))
             throw DecodingError.dataCorrupted(context)
         }
     }

--- a/Sources/BisonDecode/ParsedDocumentHelper.swift
+++ b/Sources/BisonDecode/ParsedDocumentHelper.swift
@@ -48,7 +48,10 @@ extension ReadableDoc {
             let context = DecodingError.Context(
                 codingPath: codingPath, 
                 debugDescription: "key \"\(key)\" has unknown type byte \(type)", 
-                underlyingError: DocError<Data>.unknownType(type, key, progress))
+                underlyingError: DocError<Data>.unknownType(
+                    type: type, 
+                    key: key, 
+                    progress: progress))
             throw DecodingError.dataCorrupted(context)
         } catch DocError<Data>.valueSizeMismatch(let need, let key, let progress) {
             let context = DecodingError.Context(

--- a/Sources/BisonDecode/ParsedDocumentHelper.swift
+++ b/Sources/BisonDecode/ParsedDocumentHelper.swift
@@ -42,7 +42,7 @@ extension ReadableDoc {
                 debugDescription: """
                     declared document size is \(declared) but actual size is \(data.count)
                 """,
-                underlyingError: DocError<Data>.docSizeMismatch(declared))
+                underlyingError: DocError<Data>.docSizeMismatch(expectedExactly: declared))
             throw DecodingError.typeMismatch(type, context)
         } catch DocError<Data>.unknownType(let type, let key, let progress) {
             let context = DecodingError.Context(

--- a/Sources/BisonRead/CustomReadableValue.swift
+++ b/Sources/BisonRead/CustomReadableValue.swift
@@ -29,7 +29,9 @@ public protocol CustomReadableValue: ReadableValue {
 
 extension CustomReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count >= 5 else { throw ValueError.dataTooShort(5, data.count) }
+        guard data.count >= 5 else { 
+            throw ValueError.dataTooShort(needAtLeast: 5, found: data.count) 
+        }
         let declaredSize = Int(truncatingIfNeeded: try Int32(bsonBytes: data.prefix(4)))
         guard data.count == declaredSize + 5 else {
             throw ValueError.sizeMismatch(declaredSize + 5, data.count)

--- a/Sources/BisonRead/CustomReadableValue.swift
+++ b/Sources/BisonRead/CustomReadableValue.swift
@@ -34,7 +34,7 @@ extension CustomReadableValue {
         }
         let declaredSize = Int(truncatingIfNeeded: try Int32(bsonBytes: data.prefix(4)))
         guard data.count == declaredSize + 5 else {
-            throw ValueError.sizeMismatch(declaredSize + 5, data.count)
+            throw ValueError.sizeMismatch(expected: declaredSize + 5, have: data.count)
         }
         try self.init(bsonValueBytes: data.dropFirst(5))
     }

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -64,7 +64,7 @@ public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
     /// > Note: In the case of corruption, ``notTerminated`` will usually be triggered first.
     ///   There is a chance that the corrupted data happens to be null-terminated, in whcih case
     ///   this error may be triggered instead.
-    case docSizeMismatch(_ expectedExactly: Int)
+    case docSizeMismatch(expectedExactly: Int)
 
     /// An unknown or deprecated BSON type byte was found while parsing a key.
     /// 

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -76,7 +76,7 @@ public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
     /// 
     /// This error includes a ``Progress`` value. You may check the partially decoded document
     /// within to recover from the error.
-    case valueSizeMismatch(_ needAtLeast: Int, _ key: String, _ progress: Progress<Data>)
+    case valueSizeMismatch(needAtLeast: Int, key: String, progress: Progress<Data>)
 }
 
 /// The parsed and un-parsed parts of a document after an error occured.

--- a/Sources/BisonRead/DocError.swift
+++ b/Sources/BisonRead/DocError.swift
@@ -70,7 +70,7 @@ public enum DocError<Data: Collection>: Error where Data.Element == UInt8 {
     /// 
     /// This error includes a ``Progress`` value. You may check the partially decoded document
     /// within to recover from the error.
-    case unknownType(_ type: UInt8, _ key: String, _ progress: Progress<Data>)
+    case unknownType(type: UInt8, key: String, progress: Progress<Data>)
 
     /// There were not enough bytes left in the document to parse the next expected value.
     /// 

--- a/Sources/BisonRead/ObjectID+ReadableValue.swift
+++ b/Sources/BisonRead/ObjectID+ReadableValue.swift
@@ -19,7 +19,9 @@ import ObjectID
 
 extension ObjectID: ReadableValue {
     public init<Data>(bsonBytes data: Data) throws where Data : Collection, Data.Element == UInt8 {
-        guard data.count == 12 else { throw ValueError.sizeMismatch(12, data.count) }
+        guard data.count == 12 else { 
+            throw ValueError.sizeMismatch(expected: 12, have: data.count) 
+        }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 12, alignment: 1)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: ObjectID.self)

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -190,7 +190,9 @@ extension ReadableDoc {
         guard data[terminatorIndex] == 0 else { throw DocError<Data>.notTerminated }
         // Read and check the declared size of the document against its data
         let size = Int(truncatingIfNeeded: try! Int32(bsonBytes: data.prefix(4)))
-        guard data.count == size else { throw DocError<Data>.docSizeMismatch(size) }
+        guard data.count == size else { 
+            throw DocError<Data>.docSizeMismatch(expectedExactly: size) 
+        }
 
         // Store the type map for the entire parsing process
         let typeMap = Self.typeMap

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -259,7 +259,10 @@ extension ReadableDoc {
                 // If not, compose context and throw
                 let partialDoc = ReadableDoc(discovered, minKey: minKey, maxKey: maxKey)
                 let progress = Progress(parsed: partialDoc, remaining: data[cursor...])
-                throw DocError<Data>.valueSizeMismatch(needAtLeast, key, progress)
+                throw DocError<Data>.valueSizeMismatch(
+                    needAtLeast: needAtLeast, 
+                    key: key, 
+                    progress: progress)
             }
         }
         // Assign the discovered contents

--- a/Sources/BisonRead/ReadableDoc.swift
+++ b/Sources/BisonRead/ReadableDoc.swift
@@ -234,7 +234,7 @@ extension ReadableDoc {
             guard type > 0 && type < 20 else {
                 let partialDoc = ReadableDoc(discovered, minKey: minKey, maxKey: maxKey)
                 let progress = Progress(parsed: partialDoc, remaining: data[typeIndex...])
-                throw DocError<Data>.unknownType(type, key, progress)
+                throw DocError<Data>.unknownType(type: type, key: key, progress: progress)
             }
 
             // Compute the size of the value
@@ -245,7 +245,7 @@ extension ReadableDoc {
             ) else {
                 let partialDoc = ReadableDoc(discovered, minKey: minKey, maxKey: maxKey)
                 let progress = Progress(parsed: partialDoc, remaining: data[cursor...])
-                throw DocError<Data>.unknownType(type, key, progress)
+                throw DocError<Data>.unknownType(type: type, key: key, progress: progress)
             }
 
             // Ensure there are enough bytes left in the document to store that value

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -28,7 +28,7 @@ public protocol ReadableValue {
 
 extension Int32: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 4 else { throw ValueError.sizeMismatch(4, data.count) }
+        guard data.count == 4 else { throw ValueError.sizeMismatch(expected: 4, have: data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: 4)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int32.self)
@@ -37,7 +37,7 @@ extension Int32: ReadableValue {
 
 extension Int64: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(expected: 8, have: data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Int64.self)
@@ -46,7 +46,7 @@ extension Int64: ReadableValue {
 
 extension UInt64: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(expected: 8, have: data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: UInt64.self)
@@ -55,7 +55,7 @@ extension UInt64: ReadableValue {
 
 extension Double: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 8 else { throw ValueError.sizeMismatch(8, data.count) }
+        guard data.count == 8 else { throw ValueError.sizeMismatch(expected: 8, have: data.count) }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 8, alignment: 8)
         copyBuffer.copyBytes(from: data)
         self = copyBuffer.load(as: Double.self)
@@ -64,7 +64,9 @@ extension Double: ReadableValue {
 
 extension Bool: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count == 1 else { throw ValueError.sizeMismatch(1, data.count) }
+        guard data.count == 1 else { 
+            throw ValueError.sizeMismatch(expected: 1, have: data.count) 
+        }
         self = data[data.startIndex] == 0 ? false : true
     }
 }
@@ -79,7 +81,7 @@ extension String: ReadableValue {
         // We try! here since we already ensured we have four bytes to read
         let size = Int(try! Int32(bsonBytes: data[sizeStart..<sizeEnd]))
         guard data.count == size + 4 else { 
-            throw ValueError.sizeMismatch(size + 4, data.count) 
+            throw ValueError.sizeMismatch(expected: size + 4, have: data.count) 
         }
         self.init(decoding: data[sizeEnd..<data.index(data.endIndex, offsetBy: -1)], as: UTF8.self)
     }

--- a/Sources/BisonRead/ReadableValue.swift
+++ b/Sources/BisonRead/ReadableValue.swift
@@ -71,7 +71,9 @@ extension Bool: ReadableValue {
 
 extension String: ReadableValue {
     public init<Data: Collection>(bsonBytes data: Data) throws where Data.Element == UInt8 {
-        guard data.count > 4 else { throw ValueError.dataTooShort(5, data.count) }
+        guard data.count > 4 else { 
+            throw ValueError.dataTooShort(needAtLeast: 5, found: data.count) 
+        }
         let sizeStart = data.startIndex
         let sizeEnd = data.index(sizeStart, offsetBy: 4)
         // We try! here since we already ensured we have four bytes to read

--- a/Sources/BisonRead/UUID+CustomReadableValue.swift
+++ b/Sources/BisonRead/UUID+CustomReadableValue.swift
@@ -20,7 +20,7 @@ import Foundation
 extension UUID: CustomReadableValue {
     public init<Data: Collection>(bsonValueBytes: Data) throws where Data.Element == UInt8 {
         guard bsonValueBytes.count == 16 else {
-            throw ValueError.sizeMismatch(16, bsonValueBytes.count)
+            throw ValueError.sizeMismatch(expected: 16, have: bsonValueBytes.count)
         }
         let copyBuffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 16, alignment: 1)
         copyBuffer.copyBytes(from: bsonValueBytes)

--- a/Sources/BisonRead/ValueError.swift
+++ b/Sources/BisonRead/ValueError.swift
@@ -20,7 +20,7 @@ public enum ValueError: Error, Equatable {
     /// The data passed to the initializer was shorter than the required metadata for this value.
     /// 
     /// This case provides the expected and actual size of the data passed to the initializer.
-    case dataTooShort(_ needAtLeast: Int, _ found: Int)
+    case dataTooShort(needAtLeast: Int, found: Int)
 
     /// The data passed to the initializer was not the expected size for this type.
     /// 

--- a/Sources/BisonRead/ValueError.swift
+++ b/Sources/BisonRead/ValueError.swift
@@ -25,5 +25,5 @@ public enum ValueError: Error, Equatable {
     /// The data passed to the initializer was not the expected size for this type.
     /// 
     /// This case provides the expected and actual size of the data passed to the initializer.
-    case sizeMismatch(_ expected: Int, _ have: Int)
+    case sizeMismatch(expected: Int, have: Int)
 }

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -122,7 +122,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
-            XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Int32>.size))
+            XCTAssertEqual(underlyingError, .dataTooShort(
+                needAtLeast: 5, 
+                found: MemoryLayout<Int32>.size))
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONKeyedDecodingContainerTests.swift
@@ -96,7 +96,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                ValueError.sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Int32>.size))
+                ValueError.sizeMismatch(
+                    expected: MemoryLayout<Double>.size, 
+                    have: MemoryLayout<Int32>.size))
         }
     }
 
@@ -141,7 +143,7 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             XCTAssert(attempted == String.self)
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
-            XCTAssertEqual(underlyingError, .sizeMismatch(6, 8))
+            XCTAssertEqual(underlyingError, .sizeMismatch(expected: 6, have: 8))
         }
     }
 
@@ -169,7 +171,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<UInt64>.size))
+                .sizeMismatch(
+                    expected: MemoryLayout<Bool>.size, 
+                    have: MemoryLayout<UInt64>.size))
         }
     }
 
@@ -198,7 +202,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<UInt64>.size))
+                .sizeMismatch(
+                    expected: MemoryLayout<Int32>.size, 
+                    have: MemoryLayout<UInt64>.size))
         }
     }
 
@@ -227,7 +233,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
+                .sizeMismatch(
+                    expected: MemoryLayout<Int64>.size, 
+                    have: MemoryLayout<Int32>.size))
         }
     }
 
@@ -256,7 +264,9 @@ class BSONKeyedDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))
+                .sizeMismatch(
+                    expected: MemoryLayout<UInt64>.size, 
+                    have: MemoryLayout<Int32>.size))
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
@@ -50,7 +50,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Bool>.size, container.contents.count))
+                .sizeMismatch(expected: MemoryLayout<Bool>.size, have: container.contents.count))
         }
     }
 
@@ -73,7 +73,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Double>.size, container.contents.count))
+                .sizeMismatch(expected: MemoryLayout<Double>.size, have: container.contents.count))
         }
     }
 
@@ -113,7 +113,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(13, container.contents.count))
+                .sizeMismatch(expected: 13, have: container.contents.count))
         }
     }
 
@@ -136,7 +136,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int32>.size, container.contents.count))
+                .sizeMismatch(expected: MemoryLayout<Int32>.size, have: container.contents.count))
         }
     }
 
@@ -159,7 +159,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<UInt64>.size, container.contents.count))
+                .sizeMismatch(expected: MemoryLayout<UInt64>.size, have: container.contents.count))
         }
     }
 
@@ -182,7 +182,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int64>.size, container.contents.count))
+                .sizeMismatch(expected: MemoryLayout<Int64>.size, have: container.contents.count))
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONSingleValueDecodingContainerTests.swift
@@ -96,7 +96,7 @@ class BSONSingleValueDecodingContainerTests: XCTestCase {
             let underlyingError = try XCTUnwrap(context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .dataTooShort(5, container.contents.count))
+                .dataTooShort(needAtLeast: 5, found: container.contents.count))
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -67,7 +67,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
                 context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Double>.size, MemoryLayout<Bool>.size))
+                .sizeMismatch(expected: MemoryLayout<Double>.size, have: MemoryLayout<Bool>.size))
         }
     }
 
@@ -111,7 +111,9 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
                 context.underlyingError as? ValueError)
-            XCTAssertEqual(underlyingError, .sizeMismatch(13, MemoryLayout<Int64>.size))
+            XCTAssertEqual(underlyingError, .sizeMismatch(
+                expected: 13, 
+                have: MemoryLayout<Int64>.size))
         }
     }
 
@@ -138,7 +140,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
                 context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Bool>.size, MemoryLayout<Double>.size))
+                .sizeMismatch(expected: MemoryLayout<Bool>.size, have: MemoryLayout<Double>.size))
         }
     }
 
@@ -165,7 +167,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
                 context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int32>.size, MemoryLayout<Double>.size))
+                .sizeMismatch(expected: MemoryLayout<Int32>.size, have: MemoryLayout<Double>.size))
         }
     }
 
@@ -192,7 +194,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
                 context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<Int64>.size, MemoryLayout<Int32>.size))
+                .sizeMismatch(expected: MemoryLayout<Int64>.size, have: MemoryLayout<Int32>.size))
         }
     }
 
@@ -219,7 +221,7 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
                 context.underlyingError as? ValueError)
             XCTAssertEqual(
                 underlyingError, 
-                .sizeMismatch(MemoryLayout<UInt64>.size, MemoryLayout<Int32>.size))
+                .sizeMismatch(expected: MemoryLayout<UInt64>.size, have: MemoryLayout<Int32>.size))
         }
     }
 

--- a/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
+++ b/Tests/BisonDecodeTests/BSONUnkeyedDecodingContainerTests.swift
@@ -92,7 +92,9 @@ class BSONUnkeyedDecodingContainerTests: XCTestCase {
             XCTAssertTrue(context.codingPath.isEmpty)
             let underlyingError = try XCTUnwrap(
                 context.underlyingError as? ValueError)
-            XCTAssertEqual(underlyingError, .dataTooShort(5, MemoryLayout<Bool>.size))
+            XCTAssertEqual(underlyingError, .dataTooShort(
+                needAtLeast: 5, 
+                found: MemoryLayout<Bool>.size))
         }
     }
 

--- a/Tests/BisonReadTests/ReadableDocTests.swift
+++ b/Tests/BisonReadTests/ReadableDocTests.swift
@@ -126,7 +126,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(8, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 8, key: "", progress: progress))
         }
     }
 
@@ -149,7 +149,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 5, key: "", progress: progress))
         }
     }
 
@@ -170,7 +170,10 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-                XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
+                XCTAssertEqual(error, .valueSizeMismatch(
+                    needAtLeast: 5, 
+                    key: "", 
+                    progress: progress))
         }
     }
 
@@ -192,7 +195,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(14, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 14, key: "", progress: progress))
         }
     }
 
@@ -214,7 +217,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 5, key: "", progress: progress))
         }
     }
 
@@ -236,7 +239,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(10, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 10, key: "", progress: progress))
         }
     }
     
@@ -257,7 +260,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(5, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 5, key: "", progress: progress))
         }
     }
 
@@ -280,7 +283,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(15, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 15, key: "", progress: progress))
         }
     }
 
@@ -301,7 +304,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[6...])
-            XCTAssertEqual(error, .valueSizeMismatch(6, "", progress))
+            XCTAssertEqual(error, .valueSizeMismatch(needAtLeast: 6, key: "", progress: progress))
         }
     }
 

--- a/Tests/BisonReadTests/ReadableDocTests.swift
+++ b/Tests/BisonReadTests/ReadableDocTests.swift
@@ -82,7 +82,7 @@ class ReadableDocTests: XCTestCase {
             let decodedDoc = try ReadableDoc(bsonBytes: faultyBytes)
             XCTFail("expected decoding to fail, but returned \(decodedDoc)")
         } catch let error as DocError<[UInt8]> {
-            XCTAssertEqual(error, .docSizeMismatch(3))
+            XCTAssertEqual(error, .docSizeMismatch(expectedExactly: 3))
         }
     }
 

--- a/Tests/BisonReadTests/ReadableDocTests.swift
+++ b/Tests/BisonReadTests/ReadableDocTests.swift
@@ -102,7 +102,7 @@ class ReadableDocTests: XCTestCase {
             let progress = Progress(
                 parsed: partialDoc, 
                 remaining: faultyBytes[7...])
-            XCTAssertEqual(error, .unknownType(100, "", progress))
+            XCTAssertEqual(error, .unknownType(type: 100, key: "", progress: progress))
         }
     }
 


### PR DESCRIPTION
## Objective

This pull request changes all error types to display argument labels. 

## Detailed Design

This change is meant to clarify declarations emitted by doc when building documentation. The previous documentation pages made cases cryptic, where each value had no explicit meaning. All references to error enumeration now include argument labels where appropriate.

## Alternatives Considered

In practice argument labels for enum cases are unnecessary, since code completion and placeholders display the hidden labels anyway. In fact in most cases it's actually quicker to work off of placeholders when labels are hidden compared to the new design. 
